### PR TITLE
Handle body == null situation

### DIFF
--- a/probe.js
+++ b/probe.js
@@ -99,6 +99,10 @@ function addEvent(element, eventName, fn) {
 }
 
 function get_dom_text() {
+	if (!document.body) {
+        	return '';
+    	}
+	
 	var text_extractions_to_try = [
 		document.body.outerText,
 		document.body.innerText,


### PR DESCRIPTION
Handles an edge case when Payload Fire was not triggered if HTML document had no body (e.g the document consisting only of the payload). Although we won't get much from an empty body, we still get the info that our payload was injected to the HTML document and somebody run it.